### PR TITLE
Add downsampled support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ WORK IN PROGRESS
 
 Read sequential and progressive JPEGs.
 
-* Does not support downsampled JPEGs correctly yet. Images end up garbled.
 * Does not support arithmetic encoding.
 
 ## Installation
@@ -42,10 +41,10 @@ StumpyJPEG.read("yamboli.jpg") do |canvas|
 end
 ```
 
-## To Do
+## To Do / Wishlist
 
 - [ ] JFIF header parsing support
-- [ ] Upsampling support
+- [x] Downsampled image support
 - [ ] Arithmetic encoding support
 - [ ] Add more tests
 

--- a/src/stumpy_jpeg/component.cr
+++ b/src/stumpy_jpeg/component.cr
@@ -53,7 +53,7 @@ module StumpyJPEG
               new_coords = {new_du_x + x, new_du_y + y}
 
               new_du = Matrix.new(8, 8) do |l, r, c|
-                du[c / h_sampling + h_size * x, r / v_sampling + v_size * y]
+                du[r / v_sampling + v_size * y, c / h_sampling + h_size * x]
               end
 
               upsampled_data[new_coords] = new_du
@@ -98,9 +98,6 @@ module StumpyJPEG
     end
 
     def decode_progressive_dc_first(bit_reader, dc_table, approx, du_row, du_col)
-      puts "ACFirstScan"
-      puts "0 -> 1"
-
       coef = coefficients[{du_col, du_row}]? || Array.new(64, 0)
       magnitude = dc_table.decode_from_io(bit_reader)
       @last_dc_value += read_n_extend(bit_reader, magnitude)
@@ -117,10 +114,6 @@ module StumpyJPEG
     def decode_progressive_ac_first(bit_reader, ac_table, dqt, s_start, s_end, approx, du_row, du_col)
       coef = coefficients[{du_col, du_row}]
 
-      s_sssss = s_end + 1
-      puts "ACFirstScan"
-      puts "#{s_start} -> #{s_sssss}"
-
       if @end_of_band_run > 0
         @end_of_band_run -= 1
         return
@@ -132,8 +125,6 @@ module StumpyJPEG
         
         hi = byte >> 4
         lo = byte & 0x0F
-
-        puts "Hi: #{hi}, Lo: #{lo}, i: #{i}"
 
         if lo == 0
           if hi == 0xF
@@ -156,10 +147,6 @@ module StumpyJPEG
 
     def decode_progressive_ac_refine(bit_reader, ac_table, dqt, s_start, s_end, approx, du_row, du_col)
       coef = coefficients[{du_col, du_row}]
-      
-      s_sssss = s_end + 1
-      puts "ACRefineScan"
-      puts "#{s_start} -> #{s_sssss}"
 
       if @end_of_band_run > 0
         refine_ac_non_zeroes(bit_reader, coef, s_start, s_end, 64, approx)
@@ -173,8 +160,6 @@ module StumpyJPEG
 
         hi = byte >> 4
         lo = byte & 0x0F
-
-        puts "Hi: #{hi}, Lo: #{lo}, i: #{i}"
 
         zero_run = hi
         new_val = 0

--- a/src/stumpy_jpeg/component.cr
+++ b/src/stumpy_jpeg/component.cr
@@ -31,13 +31,22 @@ module StumpyJPEG
     end
 
     def upsample(max_h, max_v)
+      h_sampling = max_h / h
+      v_sampling = max_v / v
+
+      h_size = 8 / h_sampling
+      v_size = 8 / v_sampling
+      
       data_units.each do |coords, du|
         du_x, du_y = coords
 
-        (0...max_v).each do |y|
-          (0...max_h).each do |x|
+        (0...v_sampling).each do |y|
+          (0...h_sampling).each do |x|
+            new_du = Matrix.new(8, 8) do |l, r, c|
+              du[r / h_sampling + h_size * x, c / v_sampling + v_size * y]
+            end
             dupe_coords = {du_x + x, du_y + y}
-            upsampled_data[dupe_coords] = du
+            upsampled_data[dupe_coords] = new_du
           end
         end
       end

--- a/src/stumpy_jpeg/jpeg.cr
+++ b/src/stumpy_jpeg/jpeg.cr
@@ -118,8 +118,6 @@ module StumpyJPEG
       end
       @max_h = @components.max_of { |key, comp| comp.h }
       @max_v = @components.max_of { |key, comp| comp.v }
-
-      raise "Downsampled JPEGs are not supported yet" if @max_h != 1 || @max_v != 1
     end
 
     private def parse_sos(io)

--- a/src/stumpy_jpeg/jpeg.cr
+++ b/src/stumpy_jpeg/jpeg.cr
@@ -176,9 +176,9 @@ module StumpyJPEG
             dc_table = entropy_dc_tables[s.dc_table_id]
 
             (0...component.v).each do |c_y|
-              du_row = m_y*max_v + c_y
+              du_row = m_y*component.v + c_y
               (0...component.h).each do |c_x|
-                du_col = m_x*max_h + c_x
+                du_col = m_x*component.h + c_x
                 if first_scan
                   component.decode_progressive_dc_first(reader, dc_table, sa_low, du_row, du_col)
                 else
@@ -221,16 +221,12 @@ module StumpyJPEG
             dqt = quantization_tables[component.dqt_table_id]
             ac_table = entropy_ac_tables[s.ac_table_id]
 
-            (0...component.v).each do |c_y|
-              du_row = m_y*max_v + c_y
-              (0...component.h).each do |c_x|
-                du_col = m_x*max_h + c_x
-                if first_scan
-                  component.decode_progressive_ac_first(reader, ac_table, dqt, s_start, s_end, sa_low, du_row, du_col)
-                else
-                  component.decode_progressive_ac_refine(reader, ac_table, dqt, s_start, s_end, sa_low, du_row, du_col)
-                end
-              end
+            du_row = m_y
+            du_col = m_x
+            if first_scan
+              component.decode_progressive_ac_first(reader, ac_table, dqt, s_start, s_end, sa_low, du_row, du_col)
+            else
+              component.decode_progressive_ac_refine(reader, ac_table, dqt, s_start, s_end, sa_low, du_row, du_col)
             end
           end
 
@@ -262,9 +258,9 @@ module StumpyJPEG
             ac_table = entropy_ac_tables[s.ac_table_id]
 
             (0...component.v).each do |c_y|
-              du_row = m_y*max_v + c_y
+              du_row = m_y*component.v + c_y
               (0...component.h).each do |c_x|
-                du_col = m_x*max_h + c_x
+                du_col = m_x*component.h + c_x
                 component.decode_sequential(reader, dc_table, ac_table, dqt, du_row, du_col)
               end
             end


### PR DESCRIPTION
Adds support for downsampled images (sequential and progressive). 
- Logic for ac scan refining was wrong (always skipped last coefficient). This was changed.
- Placeholder logic for upsampling was changed. Pixels should be duplicated, not entire data units.