### PR TITLE
Separate Component parts

### DIFF
--- a/src/stumpy_jpeg/component.cr
+++ b/src/stumpy_jpeg/component.cr
@@ -292,7 +292,7 @@ module StumpyJPEG
     end
   end
 
-  class ComponentSelector
+  class Component::Selector
     getter component_id : Int32
     getter dc_table_id : Int32
     getter ac_table_id : Int32
@@ -305,12 +305,14 @@ module StumpyJPEG
       io.write_byte(((dc_table_id << 4) | ac_table_id).to_u8)
     end
 
-    def self.from_io(io)
-      component_id = io.read_byte.not_nil!.to_i
+    def self.from_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)
+      raise "ByteFormat must be BigEndian" if format != IO::ByteFormat::BigEndian
 
-      ids = io.read_byte.not_nil!.to_i
-      dc_table_id = ids >> 4
-      ac_table_id = ids & 0x0F
+      component_id = format.decode(UInt8, io).to_i
+      table_ids = format.decode(UInt8, io).to_i
+
+      dc_table_id = table_ids >> 4
+      ac_table_id = table_ids & 0x0F
 
       self.new(component_id, dc_table_id, ac_table_id)
     end

--- a/src/stumpy_jpeg/segment/sof.cr
+++ b/src/stumpy_jpeg/segment/sof.cr
@@ -4,7 +4,7 @@ module StumpyJPEG
     getter height : Int32
     getter width : Int32
     getter number_of_components : Int32
-    getter components : Array(Component)
+    getter components : Array(Component::Definition)
 
     def initialize(n, @bit_precision, @height, @width, @number_of_components, @components)
       super (Markers::SOF + n)
@@ -34,8 +34,8 @@ module StumpyJPEG
       width = io.read_bytes(UInt16, IO::ByteFormat::BigEndian).to_i
       number_of_components = io.read_byte.not_nil!.to_i
 
-      components = Array(Component).new(number_of_components) do |i|
-        Component.from_io(io)
+      components = Array(Component::Definition).new(number_of_components) do |i|
+        io.read_bytes(Component::Definition, IO::ByteFormat::BigEndian)
       end
 
       self.new(0, bit_precision, height, width, number_of_components, components)

--- a/src/stumpy_jpeg/segment/sos.cr
+++ b/src/stumpy_jpeg/segment/sos.cr
@@ -1,7 +1,7 @@
 module StumpyJPEG
   class Segment::SOS < Segment
     getter number_of_components : Int32
-    getter selectors : Array(ComponentSelector)
+    getter selectors : Array(Component::Selector)
     getter spectral_start : Int32
     getter spectral_end : Int32
     getter approx_high : Int32
@@ -30,9 +30,8 @@ module StumpyJPEG
     def self.from_io(io)
       length = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
       number_of_components = io.read_byte.not_nil!.to_i
-      selectors = [] of ComponentSelector
-      number_of_components.times do
-        selectors << ComponentSelector.from_io(io)
+      selectors = Array(Component::Selector).new(number_of_components) do
+        io.read_bytes(Component::Selector, IO::ByteFormat::BigEndian)
       end
       spectral_start = io.read_byte.not_nil!.to_i
       spectral_end = io.read_byte.not_nil!.to_i


### PR DESCRIPTION
Separate the definition (sof marker) from the component used for holding the data.
- Component can be built during SOF parsing, we can remove unnecesary properties from JPEG