### PR TITLE
Fix arithmetic overflow error for images in spec

### DIFF
--- a/src/stumpy_jpeg/component.cr
+++ b/src/stumpy_jpeg/component.cr
@@ -241,7 +241,7 @@ module StumpyJPEG
     end
 
     private def extend_coefficient(bits, magnitude)
-      vt = 1 << (magnitude.to_i - 1)
+      vt = 1 << (-1 + magnitude)
       return bits + 1 + (-1 << magnitude) if bits < vt
       return bits
     end

--- a/src/stumpy_jpeg/component.cr
+++ b/src/stumpy_jpeg/component.cr
@@ -241,7 +241,7 @@ module StumpyJPEG
     end
 
     private def extend_coefficient(bits, magnitude)
-      vt = 1 << (magnitude - 1)
+      vt = 1 << (magnitude.to_i - 1)
       return bits + 1 + (-1 << magnitude) if bits < vt
       return bits
     end


### PR DESCRIPTION
The `extend_coefficient` method will always substract 1 from the magnitude (`UInt8`) and will throw an OverflowError if it is 0.